### PR TITLE
bugfix: ParseCompact should pass along unmarshaller

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -301,7 +301,7 @@ func (g *generic) parseFlat(u ...json.Unmarshaler) (JWS, error) {
 //
 // For information on the json.Unmarshaler parameter, see Parse.
 func ParseCompact(encoded []byte, u ...json.Unmarshaler) (JWS, error) {
-	return parseCompact(encoded, false)
+	return parseCompact(encoded, false, u...)
 }
 
 func parseCompact(encoded []byte, jwt bool, u ...json.Unmarshaler) (*jws, error) {

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -72,6 +72,22 @@ func TestParseCompact(t *testing.T) {
 	}
 }
 
+func TestParseCompactWithUnmarshaler(t *testing.T) {
+	j := New(easyData, crypto.SigningMethodRS512)
+	b, err := j.Compact(rsaPriv)
+	if err != nil {
+		t.Error(err)
+	}
+	var e easy
+	j2, err := ParseCompact(b, &e)
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(easyData, *j2.Payload().(*easy)) {
+		Error(t, easyData, *j2.Payload().(*easy))
+	}
+}
+
 func TestParseGeneral(t *testing.T) {
 	sm := []crypto.SigningMethod{
 		crypto.SigningMethodRS256,


### PR DESCRIPTION
I ran into a bug calling the `Parse` function with a compact token that wasn't populating my provided unmarshaller with data. This fixes my issue locally and I write a quick test demonstrating the bug as well.