### PR TITLE
Fix bug with multiple audience values

### DIFF
--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -118,7 +118,9 @@ func (c Claims) Audience() ([]string, bool) {
 		return []string{t}, true
 	case []string:
 		return t, true
-	case interface{}, []interface{}:
+	case []interface{}:
+		return stringify(t...)
+	case interface{}:
 		return stringify(t)
 	}
 	return nil, false


### PR DESCRIPTION
Hey guys, thanks for such a great library! :+1:

Unfortunately, I found a bug earlier this evening regarding multiple Audience claims. After unmarshalling a JWS, the `Audience()` method fails to return values. As it turns out, the arguments for `stringify` were not being expanded for `[]interface{}` types thus the string cast inside `stringify` was failing.

I've written a Gist with tests [here](https://gist.github.com/eliquious/ecc5d7410c0fc5c130a0). Not sure where they would belong in the repo though (because `claims_test.go` is empty right now).