### PR TITLE
Provide now parameter to JWT.Validate

### DIFF
--- a/jws/jwt.go
+++ b/jws/jwt.go
@@ -2,7 +2,6 @@ package jws
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/SermoDigital/jose/crypto"
 	"github.com/SermoDigital/jose/jwt"
@@ -66,7 +65,7 @@ func ParseJWT(encoded []byte) (jwt.JWT, error) {
 // IsJWT returns true if the JWS is a JWT.
 func (j *jws) IsJWT() bool { return j.isJWT }
 
-func (j *jws) Validate(key interface{}, m crypto.SigningMethod, v ...*jwt.Validator) error {
+func (j *jws) Validate(now float64, key interface{}, m crypto.SigningMethod, v ...*jwt.Validator) error {
 	if j.isJWT {
 		if err := j.Verify(key, m); err != nil {
 			return err
@@ -80,7 +79,7 @@ func (j *jws) Validate(key interface{}, m crypto.SigningMethod, v ...*jwt.Valida
 			if err := v1.Validate(j); err != nil {
 				return err
 			}
-			return jwt.Claims(c).Validate(float64(time.Now().Unix()), v1.EXP, v1.NBF)
+			return jwt.Claims(c).Validate(now, v1.EXP, v1.NBF)
 		}
 	}
 	return ErrIsNotJWT

--- a/jws/jwt_test.go
+++ b/jws/jwt_test.go
@@ -42,7 +42,7 @@ func TestBasicJWT(t *testing.T) {
 		Error(t, claims, w.Claims())
 	}
 
-	if err := w.Validate(rsaPub, crypto.SigningMethodRS512); err != nil {
+	if err := w.Validate(now(), rsaPub, crypto.SigningMethodRS512); err != nil {
 		t.Error(err)
 	}
 }
@@ -71,7 +71,7 @@ func TestJWTValidator(t *testing.T) {
 		return nil
 	}
 	v := NewValidator(Claims{"iss": "example.com"}, d, d, fn)
-	if err := w.Validate(rsaPub, crypto.SigningMethodRS512, v); err != nil {
+	if err := w.Validate(now(), rsaPub, crypto.SigningMethodRS512, v); err != nil {
 		t.Error(err)
 	}
 }

--- a/jws/stubs_test.go
+++ b/jws/stubs_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/SermoDigital/jose/crypto"
 )
@@ -117,4 +118,8 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func now() float64 {
+	return float64(time.Now().Unix())
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -14,7 +14,7 @@ type JWT interface {
 	// Validate returns an error describing any issues found while
 	// validating the JWT. For info on the fn parameter, see the
 	// comment on ValidateFunc.
-	Validate(key interface{}, method crypto.SigningMethod, v ...*Validator) error
+	Validate(now float64, key interface{}, method crypto.SigningMethod, v ...*Validator) error
 
 	// Serialize serializes the JWT into its on-the-wire
 	// representation.
@@ -71,7 +71,7 @@ func (v *Validator) Validate(j JWT) error {
 	}
 
 	if aud, ok := v.Expected.Audience(); ok {
-		if aud2, _ := j.Claims().Audience(); !eq(aud, aud2){
+		if aud2, _ := j.Claims().Audience(); !eq(aud, aud2) {
 			return ErrInvalidAUDClaim
 		}
 	}


### PR DESCRIPTION
JWT.Validate has implicit dependency on time.Now() which prevents time-base testing in other packages as well as using alternative time sources.