### PR TITLE
Add more precise validation function test

### DIFF
--- a/jws/jwt_test.go
+++ b/jws/jwt_test.go
@@ -63,9 +63,16 @@ func TestJWTValidator(t *testing.T) {
 
 	d := float64(time.Now().Add(1 * time.Hour).Unix())
 	fn := func(c Claims) error {
+
+		scopes, ok := c.Get("scopes").([]interface{})
+
+		if !ok {
+			return errors.New("Unexpected scopes type. Expected string")
+		}
+
 		if c.Get("name") != "Eric" &&
 			c.Get("admin") != true &&
-			c.Get("scopes").([]string)[0] != "user.account.info" {
+			scopes[0] != "user.account.info" {
 			return errors.New("invalid")
 		}
 		return nil


### PR DESCRIPTION
The previous implementation only worked due to
evaluation short-circuit.

Converting the result of `c.Get("scopes")` to `[]string` will
always fail. This is due to implementation of `json.Unmarshal`.
You have to convert to `[]interface{}` to make it work.

You can find more informations about that on:
http://blog.golang.org/json-and-go