### PR TITLE
Fix method equality to be able to validate a JWT

### DIFF
--- a/jws/jws_validate.go
+++ b/jws/jws_validate.go
@@ -196,7 +196,7 @@ func (j *jws) Verify(key interface{}, method crypto.SigningMethod) error {
 }
 
 func (s *sigHead) verify(pl []byte, key interface{}, method crypto.SigningMethod) error {
-	if s.method != method {
+	if s.method.Alg() != method.Alg() || s.method.Hasher() != method.Hasher() {
 		return ErrMismatchedAlgorithms
 	}
 	return method.Verify(format(s.Protected, pl), s.Signature, key)


### PR DESCRIPTION
Fix method equality for being abile to validate a JWT parsed from JWS
token.
Comparing the two SigningMethod interfaces produce false negative for
the most of the cases where a token is received over th wire and it has
to be parsed to JWT from a JWS as so far there isn't any other way; the
equality fails because the types which implements the interface are
defined on pointers, hence they cannot be assigned to type values and do
a comparison over the values, and the addresses never will be the same
because the one assigned to the internal field of the JWS values is one
that it's not exposed, so a new one SigningMethod (pointer) must be
provided to the `Validate`, provoking that the condition always fails