### PR TITLE
use GetTime when validating "iat" claim

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -60,7 +60,7 @@ func (v *Validator) Validate(j JWT) error {
 		return ErrInvalidSUBClaim
 	}
 	if iat, ok := v.Expected.IssuedAt(); ok {
-		if t, ok := j.Claims().GetTime("iat"); t != iat || !ok {
+		if t, ok := j.Claims().GetTime("iat"); !t.Equal(iat) || !ok {
 			return ErrInvalidIATClaim
 		}
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -60,7 +60,7 @@ func (v *Validator) Validate(j JWT) error {
 		return ErrInvalidSUBClaim
 	}
 	if iat, ok := v.Expected.IssuedAt(); ok {
-		if t, ok := j.Claims().GetTime("iat"); t != iat && ok {
+		if t, ok := j.Claims().GetTime("iat"); t != iat || !ok {
 			return ErrInvalidIATClaim
 		}
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -59,9 +59,10 @@ func (v *Validator) Validate(j JWT) error {
 		j.Claims().Get("sub") != sub {
 		return ErrInvalidSUBClaim
 	}
-	if iat, ok := v.Expected.IssuedAt(); ok &&
-		j.Claims().Get("iat") != iat {
-		return ErrInvalidIATClaim
+	if iat, ok := v.Expected.IssuedAt(); ok {
+		if t, ok := j.Claims().GetTime("iat"); t != iat && ok {
+			return ErrInvalidIATClaim
+		}
 	}
 	if jti, ok := v.Expected.JWTID(); ok &&
 		j.Claims().Get("jti") != jti {


### PR DESCRIPTION
I've noticed that validation of 'iat' field in a claim always fails. That is probably due to a change where GetTime method was introduced to set / get time related claims, but was not used at the validation step. This is one way of solving that.
