### PR TITLE
Check for empty key.

### DIFF
--- a/crypto/rsa.go
+++ b/crypto/rsa.go
@@ -42,7 +42,7 @@ func (m *SigningMethodRSA) Alg() string { return m.Name }
 // For this signing method, must be an *rsa.PublicKey.
 func (m *SigningMethodRSA) Verify(raw []byte, sig Signature, key interface{}) error {
 	rsaKey, ok := key.(*rsa.PublicKey)
-	if !ok {
+	if !ok || rsaKey == nil {
 		return ErrInvalidKey
 	}
 	return rsa.VerifyPKCS1v15(rsaKey, m.Hash, m.sum(raw), sig)
@@ -52,9 +52,10 @@ func (m *SigningMethodRSA) Verify(raw []byte, sig Signature, key interface{}) er
 // For this signing method, must be an *rsa.PrivateKey structure.
 func (m *SigningMethodRSA) Sign(data []byte, key interface{}) (Signature, error) {
 	rsaKey, ok := key.(*rsa.PrivateKey)
-	if !ok {
+	if !ok || rsaKey == nil {
 		return nil, ErrInvalidKey
 	}
+
 	sigBytes, err := rsa.SignPKCS1v15(rand.Reader, rsaKey, m.Hash, m.sum(data))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This way preventing a mandatory panic caused by crypto/rsa methods when receiving nil key. Nil key is possible because a nil interface{} gets successfully typecasted to a pointer. (I was unsure whether that panic is a tolerated result by intention, but this way at least we can decide at the handling of the error)
