### PR TITLE
Minor fixes to jwt_test.go

### DIFF
--- a/jws/jwt_test.go
+++ b/jws/jwt_test.go
@@ -37,9 +37,16 @@ func TestBasicJWT(t *testing.T) {
 		t.Error(err)
 	}
 
-	if w.Claims().Get("name") != "Eric" ||
-		w.Claims().Get("admin") != true ||
-		w.Claims().Get("scopes").([]string)[0] != "user.account.info" {
+	c := w.Claims()
+
+	scopes, ok := c.Get("scopes").([]interface{})
+	if !ok {
+		t.Error("Unexpected scopes type. Expected string")
+	}
+
+	if c.Get("name") != "Eric" ||
+		c.Get("admin") != true ||
+		scopes[0] != "user.account.info" {
 		Error(t, claims, w.Claims())
 	}
 
@@ -66,7 +73,6 @@ func TestJWTValidator(t *testing.T) {
 	fn := func(c Claims) error {
 
 		scopes, ok := c.Get("scopes").([]interface{})
-
 		if !ok {
 			return errors.New("Unexpected scopes type. Expected string")
 		}

--- a/jws/jwt_test.go
+++ b/jws/jwt_test.go
@@ -37,8 +37,8 @@ func TestBasicJWT(t *testing.T) {
 		t.Error(err)
 	}
 
-	if w.Claims().Get("name") != "Eric" &&
-		w.Claims().Get("admin") != true &&
+	if w.Claims().Get("name") != "Eric" ||
+		w.Claims().Get("admin") != true ||
 		w.Claims().Get("scopes").([]string)[0] != "user.account.info" {
 		Error(t, claims, w.Claims())
 	}
@@ -71,8 +71,8 @@ func TestJWTValidator(t *testing.T) {
 			return errors.New("Unexpected scopes type. Expected string")
 		}
 
-		if c.Get("name") != "Eric" &&
-			c.Get("admin") != true &&
+		if c.Get("name") != "Eric" ||
+			c.Get("admin") != true ||
 			scopes[0] != "user.account.info" {
 			return errors.New("invalid")
 		}


### PR DESCRIPTION
Two of the test cases in jwt_test.go perform several checks against the claimset but require that all of them be true (`&&`) in order to trigger the assert. More than likely, this is not the desired behavior and the error should actually be triggered if any (`||`) of the conditions is true.

After fixing this, I noticed that the `TestBasicJWT` test began to fail because calling `.Get('scopes')` to retrieve the scopes claim returns an `interface{}` which cannot be converted into the `[]string` value via a type assertion because it's actually an `[]interface{}` under the hood resulting in a panic now that the condition is actually being reached in the test.

The way to fix that is to change the type assertion to assert to `[]interface{}` and then compare against the `[0]` value in that slice when performing the assertion. This will probably also help new users of the library by providing a better example of how to consume slices from the claimset.