### PR TITLE
Add support for multiple authorization headers

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -414,9 +414,14 @@ func init() {
 }
 
 func fromHeader(req *http.Request) ([]byte, bool) {
-	if ah := req.Header.Get("Authorization"); len(ah) > 7 && strings.EqualFold(ah[0:7], "BEARER ") {
-		return []byte(ah[7:]), true
+	if ah := strings.Split(req.Header.Get("Authorization"), ","); len(ah) > 0 {
+		for _, h := range ah {
+			if h = strings.TrimSpace(h); len(h) > 7 && strings.EqualFold(h[0:6], "BEARER") {
+				return []byte(h[7:]), true
+			}
+		}
 	}
+
 	return nil, false
 }
 

--- a/jws/jwt_test.go
+++ b/jws/jwt_test.go
@@ -132,6 +132,38 @@ func TestFromHeader(t *testing.T) {
 	}
 
 	if string(token) != "t" {
-		t.Errorf("fromHeader should return the value set as token in the Auhorization header")
+		t.Errorf("fromHeader should return the value set as token in the Authorization header")
+	}
+
+	header.Set("Authorization", "Bearer, Basic abcdefgh")
+	_, ok = fromHeader(req)
+	if ok {
+		t.Errorf("fromHeader should return !ok when Authorization header contains Basic header but no bearer value")
+	}
+
+	header.Set("Authorization", "Basic abcdefgh, Bearer")
+	_, ok = fromHeader(req)
+	if ok {
+		t.Errorf("fromHeader should return !ok when Authorization header contains Basic header but no bearer value")
+	}
+
+	header.Set("Authorization", "Basic abcdefgh, BEARER token")
+	token, ok = fromHeader(req)
+	if !ok {
+		t.Errorf("fromHeader should return ok when Authorization header contains a value for a token")
+	}
+
+	if string(token) != "token" {
+		t.Errorf("fromHeader should return the value set as token in the Authorization header")
+	}
+
+	header.Set("Authorization", "BEARER token, Basic abcdefgh")
+	token, ok = fromHeader(req)
+	if !ok {
+		t.Errorf("fromHeader should return ok when Authorization header contains a value for a token")
+	}
+
+	if string(token) != "token" {
+		t.Errorf("fromHeader should return the value set as token in the Authorization header")
 	}
 }


### PR DESCRIPTION
Headers can have multiple values as per https://tools.ietf.org/html/rfc7230#section-3.2.2. Adding support for the possibility of multiple authorization headers