### PR TITLE
If the JWS payload is not JSON, just return the raw bytes.

### DIFF
--- a/jws/payload.go
+++ b/jws/payload.go
@@ -42,7 +42,13 @@ func (p *payload) UnmarshalJSON(b []byte) error {
 		p.v = p.u
 		return err
 	}
-	return json.Unmarshal(b2, &p.v)
+	err = json.Unmarshal(b2, &p.v)
+	if err != nil {
+		var m map[string]interface{} = make(map[string]interface{})
+		m["__rawPayload"] = b2
+		p.v = m
+	}
+	return nil
 }
 
 var (


### PR DESCRIPTION
Some JWS payloads are not encoded as JSON and are still perfectly legal[1][2]. This change
makes it so that non JSON-encoded payloads are just passed back inside the `__rawPayload`
key of the map. The type is still `map[string]interface{}` so as not to confuse any consumers.

[1] https://tools.ietf.org/html/rfc7515#section-4.1.9
[2] https://tools.ietf.org/html/rfc7515#section-2 (JWS Payload)